### PR TITLE
Fix build on 1.6.7 on linux

### DIFF
--- a/IRDuino.cpp
+++ b/IRDuino.cpp
@@ -22,8 +22,8 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 -----------------------------------------------------------------------------*/
 #include <Arduino.h>
-#include <IRduino.h>
-#include <IRduinoRecv.h>
+#include <IRDuino.h>
+#include <IRDuinoRecv.h>
 
 #define PINIR               6
 

--- a/IRDuino.cpp
+++ b/IRDuino.cpp
@@ -116,6 +116,8 @@ bool IRduino::addItem(int irCode, void (*pfun)())
 {
     ir_code[num_code]    = irCode;
     task_fun[num_code++] = pfun;
+    // FIXME: undocumented symantics... asumming returning true means successful add
+    return true;
 }
 
 /* process */

--- a/IRDuino.h
+++ b/IRDuino.h
@@ -25,6 +25,7 @@
 #define __IRDUINO_H__
 
 #include <Arduino.h>
+#include <Keyboard.h>
 #include <IRDuinoRecv.h>
 
 #define MAX_IR_CODE     50

--- a/IRDuino.h
+++ b/IRDuino.h
@@ -25,7 +25,7 @@
 #define __IRDUINO_H__
 
 #include <Arduino.h>
-#include <IRduinoRecv.h>
+#include <IRDuinoRecv.h>
 
 #define MAX_IR_CODE     50
 

--- a/IRDuino.h
+++ b/IRDuino.h
@@ -71,6 +71,11 @@
 
 #define KEY_SPACE           32
 
+// B1 below collids with the value from binary.h
+#ifdef B1
+#	undef B1
+#endif
+
 #define R1                  A0
 #define G1                  A1
 #define B1                  A2

--- a/IRDuinoRecv.cpp
+++ b/IRDuinoRecv.cpp
@@ -18,8 +18,8 @@
  * Receive Only One Byte
  *
  */
-#include "IRduinoRecvInt.h"
-#include "IRduinoRecv.h"
+#include "IRDuinoRecvInt.h"
+#include "IRDuinoRecv.h"
 
 // Provides ISR
 #include <avr/interrupt.h>

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 
 More details please goto [longan.im](longan.im)
+
+!!!This fork is not an official fork, it's just one that I made so that anyone trying to compile this on 1.0.5 in *nix can pull a working version.  If I get around to it before Longan does I'll port the code to 1.6.5 but you should look at the original source first!!!

--- a/README.md
+++ b/README.md
@@ -1,4 +1,2 @@
 
 More details please goto [longan.im](longan.im)
-
-!!!This fork is not an official fork, it's just one that I made so that anyone trying to compile this on 1.0.5 in *nix can pull a working version.  If I get around to it before Longan does I'll port the code to 1.6.5 but you should look at the original source first!!!

--- a/examples/Get_IR_Code/Get_IR_Code.ino
+++ b/examples/Get_IR_Code/Get_IR_Code.ino
@@ -24,7 +24,7 @@
   License along with this library; if not, write to the Free Software
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 -----------------------------------------------------------------------------*/
-#include <IRduino.h>
+#include <IRDuino.h>
 
 #define INFO_STR "This is an demo of IRDuino - Get IR Code\r\nMore dtails refer to https://github.com/loovee/IRDuino\r\n\r\n"
 

--- a/examples/Open_WebPage/Open_WebPage.ino
+++ b/examples/Open_WebPage/Open_WebPage.ino
@@ -27,7 +27,7 @@
   License along with this library; if not, write to the Free Software
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 -----------------------------------------------------------------------------*/
-#include <IRduino.h>
+#include <IRDuino.h>
 
 void openWebPage()
 {

--- a/examples/ShutDown/ShutDown.ino
+++ b/examples/ShutDown/ShutDown.ino
@@ -23,7 +23,7 @@
   License along with this library; if not, write to the Free Software
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 -----------------------------------------------------------------------------*/
-#include <IRduino.h>
+#include <IRDuino.h>
 
 /*
  * define your IR code here

--- a/examples/Task_Mode_Arrow/Task_Mode_Arrow.ino
+++ b/examples/Task_Mode_Arrow/Task_Mode_Arrow.ino
@@ -23,7 +23,7 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 -----------------------------------------------------------------------------*/
 
-#include <IRduino.h>
+#include <IRDuino.h>
      
 // IR CODE DEFINE
 #define IR_CODE_UP          0xee

--- a/examples/Task_Mode_Empty/Task_Mode_Empty.ino
+++ b/examples/Task_Mode_Empty/Task_Mode_Empty.ino
@@ -26,7 +26,7 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 -----------------------------------------------------------------------------*/
 
-#include <IRduino.h>
+#include <IRDuino.h>
 
 /*
  * define your IR code here

--- a/examples/Write_String/Write_String.ino
+++ b/examples/Write_String/Write_String.ino
@@ -24,7 +24,7 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 -----------------------------------------------------------------------------*/
 
-#include <IRduino.h>
+#include <IRDuino.h>
 
 #define IRCODE_LOGOUT       0xEA
 #define IRCODE_ENTERKEY     0x72

--- a/examples/cmd_mode_test/cmd_mode_test.ino
+++ b/examples/cmd_mode_test/cmd_mode_test.ino
@@ -2,7 +2,7 @@
 // n cmd t_start t_stop ....
 // Key, t_start, t_stop    unit in 10ms
 
-#include <IRduino.h>
+#include <IRDuino.h>
 
 unsigned char cmd_buf[] = {3, KEY_LEFT_CTRL, 0, 10, KEY_RIGHT_ALT, 0, 10, KEY_DELETE, 5, 10};
 unsigned char cmd_buf2[]  = {5, 'h', 0, 1, 'e', 2, 3, 'l', 4, 5, 'l', 6, 7, 'o', 8, 9};

--- a/examples/cmd_mode_uart/cmd_mode_uart.ino
+++ b/examples/cmd_mode_uart/cmd_mode_uart.ino
@@ -2,7 +2,7 @@
 // n cmd t_start t_stop ....
 // Key, t_start, t_stop    unit in 10ms
 
-#include <IRduino.h>
+#include <IRDuino.h>
 #include <EEPROM.h>
 #include "cmd_mode_dfs.h"
 


### PR DESCRIPTION
Greetings,

This patch fixes two items.

First the case changes that both ashumate and I did separately (merged his, ours were identical, found his after I did mine).

Second, this includes Keyboard.h in IRDuino.h. This fixes the missing symbol Keyboard in that header.

For me, at least, this gets the Get_IR_Code example to function. It also appears to fix issues #3 and #4.
