### PR TITLE
fix include filename case in examples

### DIFF
--- a/examples/Get_IR_Code/Get_IR_Code.ino
+++ b/examples/Get_IR_Code/Get_IR_Code.ino
@@ -24,7 +24,7 @@
   License along with this library; if not, write to the Free Software
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 -----------------------------------------------------------------------------*/
-#include <IRduino.h>
+#include <IRDuino.h>
 
 #define INFO_STR "This is an demo of IRDuino - Get IR Code\r\nMore dtails refer to https://github.com/loovee/IRDuino\r\n\r\n"
 

--- a/examples/Open_WebPage/Open_WebPage.ino
+++ b/examples/Open_WebPage/Open_WebPage.ino
@@ -27,7 +27,7 @@
   License along with this library; if not, write to the Free Software
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 -----------------------------------------------------------------------------*/
-#include <IRduino.h>
+#include <IRDuino.h>
 
 void openWebPage()
 {

--- a/examples/ShutDown/ShutDown.ino
+++ b/examples/ShutDown/ShutDown.ino
@@ -23,7 +23,7 @@
   License along with this library; if not, write to the Free Software
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 -----------------------------------------------------------------------------*/
-#include <IRduino.h>
+#include <IRDuino.h>
 
 /*
  * define your IR code here

--- a/examples/Task_Mode_Arrow/Task_Mode_Arrow.ino
+++ b/examples/Task_Mode_Arrow/Task_Mode_Arrow.ino
@@ -23,7 +23,7 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 -----------------------------------------------------------------------------*/
 
-#include <IRduino.h>
+#include <IRDuino.h>
      
 // IR CODE DEFINE
 #define IR_CODE_UP          0xee

--- a/examples/Task_Mode_Empty/Task_Mode_Empty.ino
+++ b/examples/Task_Mode_Empty/Task_Mode_Empty.ino
@@ -26,7 +26,7 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 -----------------------------------------------------------------------------*/
 
-#include <IRduino.h>
+#include <IRDuino.h>
 
 /*
  * define your IR code here

--- a/examples/Write_String/Write_String.ino
+++ b/examples/Write_String/Write_String.ino
@@ -24,7 +24,7 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 -----------------------------------------------------------------------------*/
 
-#include <IRduino.h>
+#include <IRDuino.h>
 
 #define IRCODE_LOGOUT       0xEA
 #define IRCODE_ENTERKEY     0x72

--- a/examples/cmd_mode_test/cmd_mode_test.ino
+++ b/examples/cmd_mode_test/cmd_mode_test.ino
@@ -2,7 +2,7 @@
 // n cmd t_start t_stop ....
 // Key, t_start, t_stop    unit in 10ms
 
-#include <IRduino.h>
+#include <IRDuino.h>
 
 unsigned char cmd_buf[] = {3, KEY_LEFT_CTRL, 0, 10, KEY_RIGHT_ALT, 0, 10, KEY_DELETE, 5, 10};
 unsigned char cmd_buf2[]  = {5, 'h', 0, 1, 'e', 2, 3, 'l', 4, 5, 'l', 6, 7, 'o', 8, 9};

--- a/examples/cmd_mode_uart/cmd_mode_uart.ino
+++ b/examples/cmd_mode_uart/cmd_mode_uart.ino
@@ -2,7 +2,7 @@
 // n cmd t_start t_stop ....
 // Key, t_start, t_stop    unit in 10ms
 
-#include <IRduino.h>
+#include <IRDuino.h>
 #include <EEPROM.h>
 #include "cmd_mode_dfs.h"
 


### PR DESCRIPTION
Allow examples to build on a case sensitive file system (eg: linux). Related to #4.
